### PR TITLE
Add AppHost project for telemetry and tracing integration

### DIFF
--- a/RoofTool.API/Program.cs
+++ b/RoofTool.API/Program.cs
@@ -32,6 +32,8 @@ var connectionString = builder.Configuration.GetConnectionString("DefaultConnect
 builder.Services.AddDbContext<RoofToolDbContext>(options =>
     options.UseNpgsql(connectionString));
 
+builder.Services.AddScoped<ILeadService, LeadService>();
+builder.Services.AddScoped<ILeadRepository, LeadRepository>();
 builder.Services.AddScoped<IPropertyService, PropertyService>();
 builder.Services.AddScoped<IPropertyRepository, PropertyRepository>();
 builder.Services.AddScoped<IMeasurementService, MeasurementService>();

--- a/RoofTool.API/Properties/launchSettings.json
+++ b/RoofTool.API/Properties/launchSettings.json
@@ -13,7 +13,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "http://localhost:5115",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -23,7 +22,6 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "applicationUrl": "https://localhost:7164;http://localhost:5115",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
@@ -32,7 +30,6 @@
     "IIS Express": {
       "commandName": "IISExpress",
       "launchBrowser": true,
-      "launchUrl": "swagger",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development"
       }

--- a/RoofTool.AppHost/Program.cs
+++ b/RoofTool.AppHost/Program.cs
@@ -1,0 +1,6 @@
+var builder = DistributedApplication.CreateBuilder(args);
+
+var api = builder.AddProject<Projects.RoofTool_API>("api");
+
+
+builder.Build().Run();

--- a/RoofTool.AppHost/Properties/launchSettings.json
+++ b/RoofTool.AppHost/Properties/launchSettings.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json.schemastore.org/launchsettings.json",
+  "profiles": {
+    "https": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "https://localhost:17009;http://localhost:15119",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "https://localhost:21242",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "https://localhost:22147"
+      }
+    },
+    "http": {
+      "commandName": "Project",
+      "dotnetRunMessages": true,
+      "launchBrowser": true,
+      "applicationUrl": "http://localhost:15119",
+      "environmentVariables": {
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "DOTNET_ENVIRONMENT": "Development",
+        "DOTNET_DASHBOARD_OTLP_ENDPOINT_URL": "http://localhost:19054",
+        "DOTNET_RESOURCE_SERVICE_ENDPOINT_URL": "http://localhost:20272"
+      }
+    }
+  }
+}

--- a/RoofTool.AppHost/RoofTool.AppHost.csproj
+++ b/RoofTool.AppHost/RoofTool.AppHost.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsAspireHost>true</IsAspireHost>
+    <UserSecretsId>b67e0c62-f6c1-4e59-868f-260e6fdbe860</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Hosting.AppHost" Version="8.2.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\RoofTool.API\RoofTool.API.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/RoofTool.AppHost/appsettings.Development.json
+++ b/RoofTool.AppHost/appsettings.Development.json
@@ -1,0 +1,8 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning"
+    }
+  }
+}

--- a/RoofTool.AppHost/appsettings.json
+++ b/RoofTool.AppHost/appsettings.json
@@ -1,0 +1,9 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft.AspNetCore": "Warning",
+      "Aspire.Hosting.Dcp": "Warning"
+    }
+  }
+}

--- a/RoofTool.sln
+++ b/RoofTool.sln
@@ -21,6 +21,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoofTool.ServiceDefaults", "RoofTool.ServiceDefaults\RoofTool.ServiceDefaults.csproj", "{BA116246-FAC9-43CD-B7BD-389B28AC045A}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "RoofTool.AppHost", "RoofTool.AppHost\RoofTool.AppHost.csproj", "{FF6F98B7-6F27-45BD-8A81-F2C39ACB867C}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -51,6 +53,10 @@ Global
 		{BA116246-FAC9-43CD-B7BD-389B28AC045A}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{BA116246-FAC9-43CD-B7BD-389B28AC045A}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{BA116246-FAC9-43CD-B7BD-389B28AC045A}.Release|Any CPU.Build.0 = Release|Any CPU
+		{FF6F98B7-6F27-45BD-8A81-F2C39ACB867C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{FF6F98B7-6F27-45BD-8A81-F2C39ACB867C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{FF6F98B7-6F27-45BD-8A81-F2C39ACB867C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{FF6F98B7-6F27-45BD-8A81-F2C39ACB867C}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
Introduce an AppHost project to facilitate the connection of telemetry, tracing, and resource management for the API. This includes necessary service registrations and updates to launch settings for local development.

Resources ( API currently but redis, 
![Screenshot 2024-11-20 at 10 33 04 AM](https://github.com/user-attachments/assets/8096891b-2b04-40af-b8af-229bcb2c74ed)

![Screenshot 2024-11-20 at 10 33 20 AM](https://github.com/user-attachments/assets/99895fc7-69ed-453b-a3d7-23bcd2ee48c9)

![Screenshot 2024-11-20 at 10 33 36 AM](https://github.com/user-attachments/assets/02b567ce-0884-4dc9-b81a-e7571b821c48)

